### PR TITLE
Remove Source Serif Pro from website font list

### DIFF
--- a/sass/abstracts/variables/_typography.scss
+++ b/sass/abstracts/variables/_typography.scss
@@ -1,6 +1,6 @@
 // Add chosen fonts and backups
-$font__serif: 'Source Serif Pro',Georgia,Cambria,"Times New Roman",Times,serif;
-$font__sans: 'Source Sans Pro',"Lucida Grande","Lucida Sans Unicode","Lucida Sans",Geneva,Arial,sans-serif;
+$font__serif: Georgia, Cambria, "Times New Roman", Times, serif;
+$font__sans: 'Source Sans Pro', "Lucida Grande", "Lucida Sans Unicode", "Lucida Sans", Geneva, Arial, sans-serif;
 // stylelint-disable value-keyword-case
 $font__main: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 // stylelint-enable value-keyword-case

--- a/style.css
+++ b/style.css
@@ -382,7 +382,7 @@ html {
 --------------------------------------------- */
 body, button, input, select, optgroup, textarea {
   color: #404040;
-  font-family: "Source Serif Pro", Georgia, Cambria, "Times New Roman", Times, serif;
+  font-family: Georgia, Cambria, "Times New Roman", Times, serif;
   line-height: 1.5;
 }
 


### PR DESCRIPTION
Hi @RyanQ02, @DaRealTaylor, @HarperThurlow;

The following branch removes Source Serif Pro from the theme's font list.

Can I please have one of you give the ok to merge this branch?

Regards,
@Dallas-Marshall.

**P.s. Please disregard this branch - Used for filming.**